### PR TITLE
Auto-unseal and irsa support for vault addon

### DIFF
--- a/blueprints/getting-started/main.tf
+++ b/blueprints/getting-started/main.tf
@@ -69,6 +69,13 @@ provider "helm" {
   # See https://registry.terraform.io/providers/hashicorp/helm/latest/docs#argument-reference for additional options
 }
 
+module "vault_unseal_kms" {
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/aws-kms?ref=v4.1.0"
+  alias       = "alias/${module.eks_blueprints.eks_cluster_id}-vault"
+  description = "Vault auto-unseal KMS Key for eks cluster ${local.cluster_name}"
+  policy      = null
+  tags        = {}
+}
 
 module "eks_blueprint_addons" {
   source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons"
@@ -82,7 +89,12 @@ module "eks_blueprint_addons" {
   enable_amazon_eks_kube_proxy = true
 
   # HashiCorp Vault
-  enable_vault = true
+  enable_vault                  = true
+  # turn on auto-unseal irsa config
+  vault_auto_unseal             = true
+  # pass unseal key info to module
+  vault_auto_unseal_kms_key_arn = module.vault_unseal_kms.key_arn
+  vault_auto_unseal_kms_key_id  = module.vault_unseal_kms.key_id
 
   vault_helm_config = {
     namespace = var.namespace

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,14 @@
+data "aws_iam_policy_document" "vault_iam_policy_document" {
+  count = var.auto_unseal ? 1 : 0
+  statement {
+    sid       = "VaultKMSUnseal"
+    effect    = "Allow"
+    resources = [var.auto_unseal_kms_key_arn]
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,63 +1,20 @@
-resource "helm_release" "vault" {
-  count                      = var.manage_via_gitops ? 0 : 1
-  name                       = local.helm_config["name"]
-  chart                      = local.helm_config["chart"]
-  repository                 = local.helm_config["repository"]
-  repository_key_file        = local.helm_config["repository_key_file"]
-  repository_cert_file       = local.helm_config["repository_cert_file"]
-  repository_ca_file         = local.helm_config["repository_ca_file"]
-  repository_username        = local.helm_config["repository_username"]
-  repository_password        = local.helm_config["repository_password"]
-  version                    = local.helm_config["version"]
-  namespace                  = local.helm_config["namespace"]
-  verify                     = local.helm_config["verify"]
-  keyring                    = local.helm_config["keyring"]
-  timeout                    = local.helm_config["timeout"]
-  disable_webhooks           = local.helm_config["disable_webhooks"]
-  reuse_values               = local.helm_config["reuse_values"]
-  reset_values               = local.helm_config["reset_values"]
-  force_update               = local.helm_config["force_update"]
-  recreate_pods              = local.helm_config["recreate_pods"]
-  cleanup_on_fail            = local.helm_config["cleanup_on_fail"]
-  max_history                = local.helm_config["max_history"]
-  atomic                     = local.helm_config["atomic"]
-  skip_crds                  = local.helm_config["skip_crds"]
-  render_subchart_notes      = local.helm_config["render_subchart_notes"]
-  disable_openapi_validation = local.helm_config["disable_openapi_validation"]
-  wait                       = local.helm_config["wait"]
-  wait_for_jobs              = local.helm_config["wait_for_jobs"]
-  values                     = local.helm_config["values"]
-  dependency_update          = local.helm_config["dependency_update"]
-  replace                    = local.helm_config["replace"]
-  description                = local.helm_config["description"]
-  lint                       = local.helm_config["lint"]
-  create_namespace           = local.helm_config["create_namespace"]
+#-------------------------------------
+# Helm Add-on
+#-------------------------------------
 
-  postrender {
-    binary_path = local.helm_config["postrender"]
-  }
+module "helm_addon" {
+  source            = "github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons/helm-addon?ref=v4.1.0"
+  helm_config       = local.helm_config
+  irsa_config       = local.irsa_config
+  set_values        = local.set_values
+  addon_context     = var.addon_context
+  manage_via_gitops = var.manage_via_gitops
+}
 
-  # Dynamically set non-sensitive Helm configuration options
-  # See https://www.terraform.io/language/expressions/dynamic-blocks for more information
-  dynamic "set" {
-    iterator = each_item
-    for_each = local.helm_config["set"] == null ? [] : local.helm_config["set"]
-
-    content {
-      name  = each_item.value.name
-      value = each_item.value.value
-    }
-  }
-
-  # Dynamically set SENSITIVE Helm configuration options
-  # See https://www.terraform.io/language/expressions/dynamic-blocks for more information
-  dynamic "set_sensitive" {
-    iterator = each_item
-    for_each = local.helm_config["set_sensitive"] == null ? [] : local.helm_config["set_sensitive"]
-
-    content {
-      name  = each_item.value.name
-      value = each_item.value.value
-    }
-  }
+resource "aws_iam_policy" "vault" {
+  count = var.auto_unseal ? 1 : 0
+  description = "vault IAM policy."
+  name        = "${var.addon_context.eks_cluster_id}-${local.helm_config["name"]}-irsa"
+  path        = var.addon_context.irsa_iam_role_path
+  policy      = data.aws_iam_policy_document.vault_iam_policy_document[0].json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,9 +9,29 @@ variable "addon_context" {
     eks_oidc_issuer_url            = string
     eks_oidc_provider_arn          = string
     tags                           = map(string)
+    irsa_iam_role_path             = optional(string)
+    irsa_iam_permissions_boundary  = optional(string)
   })
 
   description = "Input configuration for the addon."
+}
+
+variable "auto_unseal" {
+  type        = bool
+  default     = false
+  description = "Enable auto-unseal."
+}
+
+variable "auto_unseal_kms_key_arn" {
+  type        = string
+  default     = ""
+  description = "Optional auto-unseal key arn."
+}
+
+variable "auto_unseal_kms_key_id" {
+  type        = string
+  default     = ""
+  description = "Optional auto-unseal key id. Only needed if you are auto unsealing, and not replacing default helm config."
 }
 
 variable "helm_config" {
@@ -19,6 +39,12 @@ variable "helm_config" {
   description = "HashiCorp Vault Helm chart configuration."
 
   default = {}
+}
+
+variable "irsa_policies" {
+  description = "Additional IAM policies for a IAM role for service accounts"
+  type        = list(string)
+  default     = []
 }
 
 variable "manage_via_gitops" {

--- a/vault-config.tftpl.yml
+++ b/vault-config.tftpl.yml
@@ -29,5 +29,11 @@ server:
         storage "raft" {
           path = "/vault/data"
         }
+%{ if kms_key_id != "" ~}
+        seal "awskms" {
+          region     = "${aws_region}"
+          kms_key_id = "${kms_key_id}"
+        }
 
+%{ endif ~}
         service_registration "kubernetes" {}


### PR DESCRIPTION
There is a chicken or egg problem of needing the kms key info in order to create a custom vault config to pass to helm, but if the key is created outside of the module, and we try to base count off the existence of the arn string we end up with the "terraform cannot predict how many instances will be created" issue.  There is probably a better way to handle this, but I have not been able to piece it together.

This will also require changes to how this addon is called from aws-ia/terraform-aws-eks-blueprints.